### PR TITLE
fix: debugger not knowing which local files to point to

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "attach",
             "platform": "netCore",
             "sourceFileMap": {
-                "/src": "${workspaceFolder}"
+                "/app": "${workspaceFolder}"
             },
             "processName": "Automotive.Marketplace.Server"
         },

--- a/Automotive.Marketplace.Server/Dockerfile
+++ b/Automotive.Marketplace.Server/Dockerfile
@@ -38,7 +38,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS dev
 
 # Install Visual Studio Debugger (in order to have the ability to attach to it)
 RUN apt-get update && apt-get install -y curl unzip && \
-    curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg && \
+    curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /remote_debugger && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
debugger installation using wrong name which makes it undetectable